### PR TITLE
Added functionality for files to be named with issue number prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ Usage
 -----
 
 ```
-usage: webtoon-dl.py [-h] [-r] [-o OUTPUT] webtoon_url [webtoon_url ...]
+usage: webtoon-dl.py [-h] [-r] [-n] [-o OUTPUT] webtoon_url [webtoon_url ...]
 
   webtoon_url           Url to webtoon comic or creator page.
                         Multiple URLs may be entered.
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help            Show this help message and exit.
   -r, --raw             Save image files to folder instead of CBZ output.
+  -n, --number          Add issue numbers to file names (useful when issue names do not contain numbering).
   -o OUTPUT, --output OUTPUT
                         Path to output directory. Defaults to current directory.
 ```

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Requires
 --------
 
  * `>=Python3.6`
- * [requests-html](https://github.com/kennethreitz/requests-html)
+ * [requests_html](https://github.com/kennethreitz/requests-html)
 
 Installing
 ----------
 
-`pip3 install requests-html` or whatever
+`pip3 install requests_html` or whatever
 
 Usage
 -----

--- a/webtoon-dl.py
+++ b/webtoon-dl.py
@@ -141,6 +141,9 @@ parser.add_argument("-o", "--output",
                     default=os.getcwd(),
                     help="Path to output directory. Defaults to current directory.",
                     type=str)
+parser.add_argument("-n", "--number",
+                    help="Add episode/issue numbers to file names- useful when episodes/issue names do not contain numbering.",
+                    action="store_true")
 
 # Parse arguments
 args = parser.parse_args()
@@ -157,15 +160,20 @@ print("Found %i issues." % len(comic_list))
 
 # Save each comic
 for comic in comic_list:
-    epsiodeNumber = comic['url'].split('episode_no=')[1]
-    print("Saving issue " + epsiodeNumber + ": %s_%s..." % (comic['author'], comic['title']))
+    # Fetch the chapter/episode/issue number from the end of the URL
+    episodeNumber = comic['url'].split('episode_no=')[1]
+
+    print("Saving issue " + episodeNumber + ": %s_%s..." % (comic['author'], comic['title']))
 
     # Create output directory
     os.makedirs(args.output, exist_ok=True)
     
     # Raw mode, save images into folders
     if args.raw:
-        outpath = "%s" % args.output + "/" + epsiodeNumber + "_%s_%s" % (comic['author'], comic['title'])
+        if args.number:
+            outpath = "%s" % args.output + "/" + episodeNumber + "_%s_%s" % (comic['author'], comic['title'])
+        else:
+            outpath = "%s/%s_%s" % (args.output, comic['author'], comic['title'])
         os.makedirs(outpath, exist_ok=True)
         
         # Write each image to folder

--- a/webtoon-dl.py
+++ b/webtoon-dl.py
@@ -157,14 +157,15 @@ print("Found %i issues." % len(comic_list))
 
 # Save each comic
 for comic in comic_list:
-    print("Saving %s_%s..." % (comic['author'], comic['title']))
-    
+    epsiodeNumber = comic['url'].split('episode_no=')[1]
+    print("Saving issue " + epsiodeNumber + ": %s_%s..." % (comic['author'], comic['title']))
+
     # Create output directory
     os.makedirs(args.output, exist_ok=True)
     
     # Raw mode, save images into folders
     if args.raw:
-        outpath = "%s/%s_%s" % (args.output, comic['author'], comic['title'])
+        outpath = "%s" % args.output + "/" + epsiodeNumber + "_%s_%s" % (comic['author'], comic['title'])
         os.makedirs(outpath, exist_ok=True)
         
         # Write each image to folder
@@ -181,5 +182,4 @@ for comic in comic_list:
             for index, image in enumerate(comic['page-img']):
                 zip.writestr("%i.jpg" % index, image)
 
-    
 print("Done")


### PR DESCRIPTION
I noticed that some comics don't include issue number in the issue titles, such that when downloaded they are randomly ordered. (Examples: _Zomcom_ or _Scoob and Shag_, see issue #1 ) 

I have added a flag (-n, --number) that adds a number prefix to each downloaded issue based on the URL it came from. The URL for each issue ends in "episode_no=n" (unpadded), so I used that value. I updated the README to reflect this new functionality.

(I also corrected the README to refer to 'requests_html' instead of 'requests-html', which I believe was incorrect.)

Thanks for this tool! It's great.